### PR TITLE
explicitly enable the EPEL repo during installation (RedHat)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,7 @@
 ---
 
 - import_tasks: variables.yml
-
-- name: install nrpe
-  ansible.builtin.package:
-    name: '{{ nrpe_packages }}'
-  register: nrpe_installed
-  until: nrpe_installed is succeeded
+- include_tasks: 'setup-{{ ansible_os_family }}.yml'
 
 - name: configure nrpe
   ansible.builtin.template:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,0 +1,10 @@
+---
+
+- name: install nrpe
+  ansible.builtin.yum:
+    name: '{{ nrpe_packages }}'
+    enablerepo: '{{ __nrpe_enablerepos }}'
+  register: nrpe_installed
+  until: nrpe_installed is succeeded
+
+...

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,4 +7,7 @@ __nrpe_packages:
   - nagios-plugins-users
   - nagios-plugins-disk
 
+__nrpe_enablerepos:
+  - epel
+
 ...


### PR DESCRIPTION
Do not assume the user has it enabled by default on their hosts. Since this role anyway depends on EPEL for the RedHat OS family, simply enable it one-time during installation. Need to use the yum module for this to work.